### PR TITLE
word level

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,22 @@
 
 This plugin checks a user defined json for utterance fixes `~/.local/share/mycroft/corrections.json`
 
-
+fuzzy matching is used to determine if a utterance matches the transcription
+if >=0.85% similarity then the replacement is returned instead of the original transcription
 ```json
 {
     "I hate open source": "I love open source",
     "do the thing": "trigger protocol 404"
+}
+```
+
+you can also define unconditional replacements at word level `~/.local/share/mycroft/word_corrections.json`
+
+for example whisper STT often gets artist names wrong, this allows you to correct them
+```json
+{
+    "Jimmy Hendricks": "Jimi Hendrix",
+    "Eric Klapptern": "Eric Clapton",
+    "Eric Klappton": "Eric Clapton"
 }
 ```

--- a/ovos_utterance_corrections_transformer/__init__.py
+++ b/ovos_utterance_corrections_transformer/__init__.py
@@ -12,11 +12,20 @@ class UtteranceCorrectionsPlugin(UtteranceTransformer):
     def __init__(self, name="ovos-utterance-corrections", priority=1):
         super().__init__(name, priority)
         self.db = JsonStorage(path=f"{xdg_data_home()}/{get_xdg_base()}/corrections.json")
+        self.words_db = JsonStorage(path=f"{xdg_data_home()}/{get_xdg_base()}/word_corrections.json")
 
     def transform(self, utterances: List[str], context: Optional[dict] = None) -> (list, dict):
         context = context or {}
+
+        # replace full utterance
         replacement, conf = match_one(utterances[0], self.db)  # TODO - match strategy from conf
-        if conf >= 0.8:  # TODO make configurable
+        if conf >= 0.85:  # TODO make configurable
             return [replacement], context
+
+        # replace individual words
+        for idx in range(len(utterances)):
+            for w, r in self.words_db.items():
+                utterances[idx] = utterances[idx].replace(w, r)
+
         return utterances, context
 


### PR DESCRIPTION
you can also define unconditional replacements at word level `~/.local/share/mycroft/word_corrections.json`

for example whisper STT often gets artist names wrong, this allows you to correct them
```json
{
    "Jimmy Hendricks": "Jimi Hendrix",
    "Eric Klapptern": "Eric Clapton",
    "Eric Klappton": "Eric Clapton"
}