### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # Utterance Corrections plugin
 
-This plugin provides tools to correct or adjust speech-to-text (STT) outputs for better intent matching or improved user experience.
+This plugin corrects speech-to-text (STT) output before intent matching. It is an [OVOS](https://github.com/OpenVoiceOS) text transformer plugin that applies user-defined replacements to each utterance.
 
-### Key Features:
-1. **"Secret Speech"**: Map random utterances to something else so you can furtively give orders to your assistant.
-2. **Shortcuts**: Map shorter utterances or slang to known utterances that trigger the correct intent.
-3. **Manual STT Fixes**: Correct common STT transcription errors you experimentally determined.
+The plugin supports three kinds of corrections:
+1. **Full utterance corrections**: map a whole phrase to a different phrase, matched by fuzzy string similarity.
+2. **Word-level corrections**: replace specific words or names, regardless of the rest of the sentence.
+3. **Regex-based corrections**: replace text that matches a regular expression.
+
+---
+
+## Install
+
+```bash
+pip install ovos-utterance-corrections-plugin
+```
+
+The plugin registers itself as an OVOS transformer plugin under the entry point group `opm.transformer.text`, so [ovos-core](https://github.com/OpenVoiceOS/ovos-core) picks it up automatically once installed.
 
 ---
 
 ## 1. Full Utterance Corrections
 
-This plugin checks a user-defined JSON file for **utterance fixes** at `~/.local/share/mycroft/corrections.json`.
+This plugin reads a user-defined JSON file for utterance fixes at `~/.local/share/mycroft/corrections.json`.
 
-**Fuzzy matching** is used to determine if an utterance matches a transcription. If similarity is greater than or equal to **85%**, the replacement is returned instead of the original transcription.
+Fuzzy matching compares each utterance against the entries in this file. If the similarity is 85% or higher, the plugin returns the mapped replacement instead of the original transcription. This lets you map a random utterance to a different one, for example to give your assistant a command through an unrelated phrase.
 
 ### Example: `corrections.json`
 ```json
@@ -23,19 +33,19 @@ This plugin checks a user-defined JSON file for **utterance fixes** at `~/.local
 }
 ```
 
-**Input**:  
-`"I hat open source"`  
+**Input**:
+`"I hat open source"`
 
-**Output**:  
+**Output**:
 `"I love open source"`
 
 ---
 
 ## 2. Word-Level Corrections
 
-You can also define unconditional word-level replacements in `~/.local/share/mycroft/word_corrections.json`.  
+Define unconditional word-level replacements in `~/.local/share/mycroft/word_corrections.json`.
 
-This is particularly useful when STT models repeatedly transcribe specific names or words incorrectly.
+Use this file when an STT model repeatedly mistranscribes specific names or words.
 
 ### Example: `word_corrections.json`
 ```json
@@ -46,22 +56,21 @@ This is particularly useful when STT models repeatedly transcribe specific names
 }
 ```
 
-**Input**:  
-`"I love Jimmy Hendricks"`  
+**Input**:
+`"I love Jimmy Hendricks"`
 
-**Output**:  
+**Output**:
 `"I love Jimi Hendrix"`
 
-
-> **use case**: whisper STT often does this mistake in it's transcriptions
+For example, Whisper STT often mistranscribes names this way.
 
 ---
 
 ## 3. Regex-Based Corrections
 
-For more complex corrections, you can use **regular expressions** in `~/.local/share/mycroft/regex_corrections.json`.  
+For more complex corrections, use regular expressions in `~/.local/share/mycroft/regex_corrections.json`.
 
-This is useful for fixing consistent patterns in STT errors, such as replacing incorrect trigraphs.
+Use this file to fix consistent patterns in STT errors, such as a model that substitutes one trigraph for another.
 
 ### Example: `regex_corrections.json`
 ```json
@@ -71,36 +80,44 @@ This is useful for fixing consistent patterns in STT errors, such as replacing i
 ```
 
 ### Explanation:
-- **`\\bsh(\\w*)`**: Matches words starting with `sh` at a word boundary.
-- **`sch\\1`**: Replaces `sh` with `sch` and appends the rest of the word.
+- `\\bsh(\\w*)` matches words that start with `sh` at a word boundary.
+- `sch\\1` replaces `sh` with `sch` and keeps the rest of the word.
 
 ### Example Usage:
-**Input**:  
-`"shalter is a switch"`  
+**Input**:
+`"shalter is a switch"`
 
-**Output**:  
+**Output**:
 `"schalter is a switch"`
 
-> **use case**: citrinet german model often does this mistake in it's transcriptions
+For example, the Citrinet German model often makes this mistake.
 
 ---
 
 ## Configuration Paths
 
 | File                      | Purpose                               |
-|---------------------------|---------------------------------------|
+|---------------------------|----------------------------------------|
 | `corrections.json`        | Full utterance replacements.          |
 | `word_corrections.json`   | Word-level replacements.              |
 | `regex_corrections.json`  | Regex-based pattern replacements.     |
 
-All correction files are stored under:  
-`~/.local/share/mycroft/`
+All correction files live under `~/.local/share/mycroft/`.
 
 ---
 
-### Usage Scenarios
-- **Improve Intent Matching**: Ensure consistent STT output for accurate intent triggers.
-- **Fix Model-Specific Errors**: Handle recurring transcription mistakes in certain STT engines.
-- **Shortcut Commands**: Simplify complex commands with shorter phrases or slang.
+## Usage Scenarios
 
-Let us know how you're using this plugin, and feel free to contribute regex examples to this README or new use cases! 🚀
+- **Improve intent matching**: normalize STT output so the same phrase always triggers the same intent.
+- **Fix model-specific errors**: correct transcription mistakes that a given STT engine repeats.
+- **Shortcut commands**: map a short phrase or slang term to the full utterance that triggers an intent.
+
+## Related projects
+
+- [ovos-utterance-normalizer](https://github.com/OpenVoiceOS/ovos-utterance-normalizer) — another OVOS text transformer plugin, for normalizing utterance formatting.
+- [ovos-dialog-normalizer-plugin](https://github.com/OpenVoiceOS/ovos-dialog-normalizer-plugin) — normalizes dialog output.
+- [ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager) — defines the transformer plugin interface this plugin implements.
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
Rewrites the README for clarity: adds an install section, tightens the prose per correction type, and links related OVOS transformer plugins. No behavior, feature, or license changes.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with installation and configuration instructions.
  * Documented supported correction types, including full-utterance, word-level, and regex corrections.
  * Added usage examples, automatic registration details, related projects, and licensing information.
  * Clarified example explanations and usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->